### PR TITLE
update grammar in snippets files

### DIFF
--- a/snippets/constants.cson
+++ b/snippets/constants.cson
@@ -1,4 +1,4 @@
-".text.html":
+".text.html.php":
 	"XMLRPC_REQUEST":
     "prefix": "XMLRPC_REQUEST"
     "body": "XMLRPC_REQUEST"

--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -1,4 +1,4 @@
-".text.html":
+".text.html.php":
 	"_get_cron_lock":
 		"prefix": "_get_cron_lock"
 		"body": "_get_cron_lock()"

--- a/snippets/snippets.cson
+++ b/snippets/snippets.cson
@@ -1,4 +1,4 @@
-".text.html":
+".text.html.php":
 	"Enqueue a script":
     "prefix": "wp_enqueue_template"
     "body": """

--- a/snippets/wordpress.cson
+++ b/snippets/wordpress.cson
@@ -1,4 +1,4 @@
-'.text.html':
+'.text.html.php':
   'Action':
     'prefix': 'wpact'
     'body': 'add_action(\'${1:hook}\',\'${2:callback-function}\',${3:10},${4:1});'


### PR DESCRIPTION
Hi, I changed the grammar of these snippet files from .text.html to .text.html.php because the WP snippets were trying to autocomplete when I was trying to just write HTML. This way they only come up when I'm working on PHP files, and it makes it a more useful extension!